### PR TITLE
OpenMP Variant split-loop reduction

### DIFF
--- a/src/simple_whole_cpu_parallel_omp/variant_configure.cpp
+++ b/src/simple_whole_cpu_parallel_omp/variant_configure.cpp
@@ -11,7 +11,7 @@
 #include <stdbool.h>
 
 void printVariantInformationMessage( FILE* stream ){
-  fprintf( stream, "This is the LIKELY BROKEN CPU parallel via OpenMP in macro loops implementation of the LowFlow mini-app\n" );
+  fprintf( stream, "This is the CPU parallel via OpenMP in macro loops implementation of the LowFlow mini-app\n" );
 }
 
 void printVariantOptionsMessage( FILE* stream ){

--- a/src/simple_whole_cpu_parallel_omp/variant_metrics.cpp
+++ b/src/simple_whole_cpu_parallel_omp/variant_metrics.cpp
@@ -3,14 +3,16 @@
 void printVariantMetricInformation( FILE* stream, Variant_Metrics* metrics ){
 #ifdef ENABLE_VARIANT_METRICS
   fprintf( stream,
-    "Elapsed 216: %f\n"
-    "Elapsed 338: %f\n"
-    "Elapsed 416: %f\n"
-    "Elapsed 551: %f\n",
+    "Elapsed 216:        %fs\n"
+    "Elapsed 338:        %fs\n"
+    "Elapsed 416:        %fs\n"
+    "Elapsed 551:        %fs\n"
+    "Elapsed 551_reduce: %fs\n",
     metrics->elapsed_216,
     metrics->elapsed_338,
     metrics->elapsed_416,
-    metrics->elapsed_551
+    metrics->elapsed_551,
+    metrics->elapsed_551_reduce
   );
 #else
   /* Do nothing */

--- a/src/simple_whole_cpu_parallel_omp/variant_metrics.hpp
+++ b/src/simple_whole_cpu_parallel_omp/variant_metrics.hpp
@@ -18,7 +18,7 @@ typedef struct struct_Variant_Metrics {
   double elapsed_338;
   double elapsed_416;
   double elapsed_551;
-
+  double elapsed_551_reduce;
 } Variant_Metrics;
 
 #endif


### PR DESCRIPTION
Updated openmp variant to be parallel safe with the
split loop reduction method.
All tests pass.